### PR TITLE
fix: accept `assertRum` parameter and fix version upgrade

### DIFF
--- a/.es_template.js
+++ b/.es_template.js
@@ -33,6 +33,9 @@ const template = {
                       }
                   }
               ],
+              "_meta": {
+                "api_version": nconf.get('env:APP_VERSION')
+              },
               "_all": {
                   "enabled": false
               }
@@ -104,7 +107,10 @@ const template = {
                 }
               }
             }
-          ]
+          ],
+          "_meta": {
+            "api_version": nconf.get('env:APP_VERSION')
+          }
         }
       },
       "aliases": {}

--- a/routes/v2/post-routes.js
+++ b/routes/v2/post-routes.js
@@ -92,6 +92,7 @@ function validateSchema(route, body) {
     }),
     flags: joi.object({
       assertBaseline: joi.boolean(),
+      assertRum: joi.boolean(),
       debug: joi.boolean(),
       esTrace: joi.boolean(),
       esCreate: joi.boolean(),

--- a/src/run-es.js
+++ b/src/run-es.js
@@ -97,13 +97,10 @@ class Elastic {
   }
 
   async checkUpgrade() {
-    nconf.set('env:CURR_VERSION', await this.es.getTmplVer());
-    nconf.set('env:NEW_VERSION', parseInt(this.env.APP_VERSION.replace(/\./g, ''), 10) || nconf.get('env:CURR_VERSION'));
     nconf.set('env:KB_VERSION', await this.es.getKBVer());
     nconf.set('env:KB_MAJOR', parseInt(nconf.get('env:KB_VERSION').substr(0, 1), 10));
     this.env = nconf.get('env');
     const upgrade = (
-      (this.env.CURR_VERSION < this.env.NEW_VERSION) ||
       (this.env.KB_MAJOR < this.env.ES_MAJOR) ||
       nconf.get('es_upgrade') === true
     );
@@ -111,7 +108,6 @@ class Elastic {
       this.es.logElastic('info', `[UPDATE] ` +
       `Force: ${nconf.get('es_upgrade')} - ` +
       `New: ${!this.env.KB_MAJOR} - ` +
-      `Update: ${this.env.CURR_VERSION < this.env.NEW_VERSION} - ` +
       `Upgrade: ${this.env.KB_MAJOR < this.env.ES_MAJOR}`);
     }
     return upgrade;

--- a/src/v2/es-utils.js
+++ b/src/v2/es-utils.js
@@ -194,17 +194,6 @@ class ESClass {
     return '0';
   }
 
-  async getTmplVer() {
-    try {
-      const currTemplate = await this.getTemplate(this.env.INDEX_PERF);
-      return currTemplate[this.env.INDEX_PERF].version;
-    } catch (err) {
-      if (err) {
-        return 0;
-      }
-    }
-  }
-
   async index(index, type, id, body) {
     if (parseInt(this.env.ES_MAJOR, 10) > 5) {
       body.type = type;

--- a/src/v2/es-utils.js
+++ b/src/v2/es-utils.js
@@ -194,6 +194,18 @@ class ESClass {
     return '0';
   }
 
+  async getTmplVer(esVersion) {
+    try {
+      const currTemplate = await this.getTemplate(this.env.INDEX_PERF);
+      const type = esVersion > 5 ? 'doc' : '_default_';
+      return currTemplate[this.env.INDEX_PERF].mappings[type]._meta.api_version;
+    } catch (err) {
+      if (err) {
+        return 0;
+      }
+    }
+  }
+
   async index(index, type, id, body) {
     if (parseInt(this.env.ES_MAJOR, 10) > 5) {
       body.type = type;

--- a/src/v2/perf-utils.js
+++ b/src/v2/perf-utils.js
@@ -25,6 +25,10 @@ class PUClass {
     this.errorMsg = [];
     this.dl = '';
     this.timing = {};
+    if (this.body.hasOwnProperty('flags') && this.body.flags.hasOwnProperty('assertRum')) {
+      this.body.flags.assertBaseline = this.body.flags.assertRum;
+      delete this.body.flags.assertRum;
+    }
     this.objParams = this.mergeDeep({}, this.defaults, body);
     if (body.hasOwnProperty('sla')) {
       this.assertMetric = Object.keys(body.sla)[0] || '';


### PR DESCRIPTION
- added old `assertRum` param to validator so old clients don't fail
- not updating KB items based on API version - use env variable instead