### PR TITLE
Fix issue with semantic-release

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "perfeng",
         "performance"
     ],
-    "repository": "godaddy/timings",
+    "repository": "https://github.com/godaddy/timings.git",
     "author": "GoDaddy Operating Company, LLC",
     "contributors": [
         "Marcel Verkerk <mverkerk@godaddy.com>"


### PR DESCRIPTION
Malformed repository URL in package.json - has to be full URL